### PR TITLE
Guest Role for non-UCLA users

### DIFF
--- a/commands/getUser.js
+++ b/commands/getUser.js
@@ -1,6 +1,6 @@
 const sqlite = require('sqlite');
 const sqlite3 = require('sqlite3');
-const config = require('../config.'+process.env.NODE_ENV_MODE);
+const config = require('../config.' + process.env.NODE_ENV_MODE);
 
 // create user info message using Discord Message Embed for better formatting
 async function createUserInfoMsg(row, title, description, server, Discord) {
@@ -32,13 +32,13 @@ async function createUserInfoMsg(row, title, description, server, Discord) {
 
 // who are you???
 // linked to WHOAMI command
-const whoami = async function (userid, server, Discord) {
+const whoami = async function(userid, server, Discord) {
   // open db
   let db = await sqlite.open({
     filename: config.db_path,
     driver: sqlite3.Database,
   });
-    
+
   // check if user is verified
   let row = null;
   try {
@@ -62,10 +62,10 @@ const whoami = async function (userid, server, Discord) {
       null,
       `
 Hmmm I'm really not sure myself but I'd love to get to know you!
-Use \`!iam <affiliation> <name> <ucla_email>\` and verify your email address.`,
+Use \`!iam <affiliation> <name> <edu_email>\` and verify your email address.`,
     ];
   }
-    
+
   return [
     null,
     await createUserInfoMsg(row, 'About You', `Why, you're ${row.nickname} of course!`, server, Discord)
@@ -75,13 +75,13 @@ Use \`!iam <affiliation> <name> <ucla_email>\` and verify your email address.`,
 // get information on a user by discord username (note: users can change this)
 // only `userid` is invariant. Use getUserById
 // linked to LOOKUP command
-const getUserByUsername = async function (username, discriminator, server, Discord) {
+const getUserByUsername = async function(username, discriminator, server, Discord) {
   // open db
   let db = await sqlite.open({
     filename: config.db_path,
     driver: sqlite3.Database,
   });
-    
+
   // check if user is verified
   let row = null;
   try {
@@ -101,23 +101,23 @@ const getUserByUsername = async function (username, discriminator, server, Disco
     return [{ message: e.toString() }, null];
   }
   await db.close();
-    
+
   if (!row) {
     return [null, 'User not found/verified.'];
   }
-    
+
   return [null, await createUserInfoMsg(row, 'User Information', `Moderator Lookup on ${row.userid}`, server, Discord)];
 };
 
 // get information on a user by discord username (note: users can change this)
 // linked to LOOKUP command
-const getUserById = async function (userid, server, Discord) {
+const getUserById = async function(userid, server, Discord) {
   // open db
   let db = await sqlite.open({
     filename: config.db_path,
     driver: sqlite3.Database,
   });
-    
+
   // check is user is verified
   let row = null;
   try {
@@ -136,12 +136,12 @@ const getUserById = async function (userid, server, Discord) {
     return [{ message: e.toString() }, null];
   }
   await db.close();
-    
+
   if (!row) {
     return [null, 'User not found/verified.'];
   }
-    
+
   return [null, await createUserInfoMsg(row, 'User Information', `Moderator Lookup on ${row.userid}`, server, Discord)];
 };
 
-module.exports = {whoami, getUserByUsername, getUserById};
+module.exports = { whoami, getUserByUsername, getUserById };

--- a/commands/iam.js
+++ b/commands/iam.js
@@ -1,6 +1,6 @@
 const sqlite = require('sqlite');
 const sqlite3 = require('sqlite3');
-const config = require('../config.'+process.env.NODE_ENV_MODE);
+const config = require('../config.' + process.env.NODE_ENV_MODE);
 
 // generates a n-digit random code
 function genCode(n) {
@@ -13,35 +13,49 @@ function genCode(n) {
 
 // if email has not been verified, send verification code
 // linked to IAM command
-const iam = async function (userid, email, nickname, affiliation, sgMail) {
-  // check email against allowed domains
-  let domain = email.match(
-    '^[a-zA-Z0-9_.+-]+@(?:(?:[a-zA-Z0-9-]+.)?[a-zA-Z]+.)?(' +
-        config.allowed_domains.join('|') +
-        ')$'
-  );
-  if (!(domain && config.allowed_domains.includes(domain[1]))) {
-    return [null, 'Please enter a valid UCLA email address (example@cs.ucla.edu).'];
-  }
-  
-  // nickname length less than 20 characters to allow for pronouns
-  // discord nickname max length 32 chars
-  if (nickname.length > 19) {
-    return [null, 'Please enter a shorter name (max 19 characters).'];
-  }
-  
+const iam = async function(userid, email, nickname, affiliation, sgMail) {
   // TODO: store affil_key and not entire string to reduce storage on db
   let affil_key = config.affiliation_map[affiliation];
   if (!affil_key) {
     return [null, 'Please provide a valid affiliation (student/alumni/other).'];
   }
-  
+
+  if (affil_key === 'o') {
+    let domain = email.match(
+      '^[a-zA-Z0-9_.+-]+@(?:(?:[a-zA-Z0-9-]+.)?[a-zA-Z]+.)?.+\.edu$'
+    );
+
+    if (!domain) {
+      return [null, 'Please enter a valid college/university email address (example@university.edu).'];
+    }
+  }
+
+  else {
+    // check email against allowed domains
+    // for non-other roles
+    let domain = email.match(
+      '^[a-zA-Z0-9_.+-]+@(?:(?:[a-zA-Z0-9-]+.)?[a-zA-Z]+.)?(' +
+      config.allowed_domains.join('|') +
+      ')$'
+    );
+
+    if (!(domain && config.allowed_domains.includes(domain[1]))) {
+      return [null, 'Please enter a valid UCLA email address (example@cs.ucla.edu).'];
+    }
+  }
+
+  // nickname length less than 20 characters to allow for pronouns
+  // discord nickname max length 32 chars
+  if (nickname.length > 19) {
+    return [null, 'Please enter a shorter name (max 19 characters).'];
+  }
+
   // open db
   const db = await sqlite.open({
     filename: config.db_path,
     driver: sqlite3.Database,
   });
-  
+
   // check if email is already verified
   let emailExists = null;
   try {
@@ -56,7 +70,7 @@ const iam = async function (userid, email, nickname, affiliation, sgMail) {
     await db.close();
     return [null, 'This email has already been verified. If you own this email address, please contact any of the Moderators.'];
   }
-  
+
   // send 6-digit code to provided email
   const code = genCode(config.discord.gen_code_length);
   const msg = {
@@ -98,11 +112,11 @@ const iam = async function (userid, email, nickname, affiliation, sgMail) {
     return [{ message: e.toString() }, null];
   }
   await db.close();
-  
+
   return [
     null,
     `Please check your email \`${email}\` for a 6-digit verification code. Verify using \`!verify <code>\``,
   ];
 };
 
-module.exports = {iam};
+module.exports = { iam };

--- a/commands/setUser.js
+++ b/commands/setUser.js
@@ -1,21 +1,21 @@
 const sqlite = require('sqlite');
 const sqlite3 = require('sqlite3');
-const config = require('../config.'+process.env.NODE_ENV_MODE);
+const config = require('../config.' + process.env.NODE_ENV_MODE);
 
 // add pronouns to nickname
 // linked to PRONOUNS command
-const setPronouns = async function (userid, pronouns, server) {
+const setPronouns = async function(userid, pronouns, server) {
   // pronouns string should be less than 11 chars
   if (pronouns.length > 10) {
     return [null, 'Please enter something shorter (max 10 characters).'];
   }
-    
+
   // open db
   let db = await sqlite.open({
     filename: config.db_path,
     driver: sqlite3.Database,
   });
-    
+
   // check if user is verified
   let row = null;
   try {
@@ -39,10 +39,10 @@ const setPronouns = async function (userid, pronouns, server) {
       null,
       `
 Sorry, I don't think you're verified!.
-Use \`!iam <affiliation> <name> <ucla_email>\` to verify your email address.`,
+Use \`!iam <affiliation> <name> <edu_email>\` to verify your email address.`,
     ];
   }
-    
+
   // set pronouns in db
   try {
     await db.run(
@@ -61,11 +61,11 @@ Use \`!iam <affiliation> <name> <ucla_email>\` to verify your email address.`,
     return [{ message: e.toString() }, null];
   }
   await db.close();
-    
+
   // set pronouns in nickname on server
   let member = await server.members.fetch(userid);
   member.setNickname(`${row.nickname} (${pronouns})`);
-    
+
   return [
     null,
     `
@@ -76,18 +76,18 @@ Thank you for making the server more inclusive!`
 
 // add major in database record
 // linked to MAJOR command
-const setMajor = async function (userid, major) {
+const setMajor = async function(userid, major) {
   // check major against official list
   if (!config.majors_list.includes(major)) {
     return [null, 'Sorry, I don\'t recognize your major! Please refer to https://catalog.registrar.ucla.edu/ucla-catalog20-21-5.html for valid major names (e.g. Computer Science).'];
   }
-    
+
   // open db
   let db = await sqlite.open({
     filename: config.db_path,
     driver: sqlite3.Database,
   });
-    
+
   // check if user is verified
   let row = null;
   try {
@@ -111,10 +111,10 @@ const setMajor = async function (userid, major) {
       null,
       `
 Sorry, I don't think you're verified!.
-Use \`!iam <affiliation> <name> <ucla_email>\` and verify your email address.`,
+Use \`!iam <affiliation> <name> <edu_email>\` and verify your email address.`,
     ];
   }
-    
+
   // set major in db
   try {
     await db.run(
@@ -133,7 +133,7 @@ Use \`!iam <affiliation> <name> <ucla_email>\` and verify your email address.`,
     return [{ message: e.toString() }, null];
   }
   await db.close();
-    
+
   return [
     null,
     `Successfully added your major (${major}). Thank you!`
@@ -142,18 +142,18 @@ Use \`!iam <affiliation> <name> <ucla_email>\` and verify your email address.`,
 
 // add year in database record
 // linked to YEAR command
-const setYear = async function (userid, year) {
+const setYear = async function(userid, year) {
   // validate year (1900-2099)
-  if(!year.match('^(?:(?:19|20)[0-9]{2})$')) {
+  if (!year.match('^(?:(?:19|20)[0-9]{2})$')) {
     return [null, 'Please enter a valid graduation year.'];
   }
-    
+
   // open db
   let db = await sqlite.open({
     filename: config.db_path,
     driver: sqlite3.Database,
   });
-    
+
   //c check if user is verified
   let row = null;
   try {
@@ -177,10 +177,10 @@ const setYear = async function (userid, year) {
       null,
       `
 Sorry, I don't think you're verified!.
-Use \`!iam <affiliation> <name> <ucla_email>\` and verify your email address.`,
+Use \`!iam <affiliation> <name> <edu_email>\` and verify your email address.`,
     ];
   }
-    
+
   // set graduation year in db
   try {
     await db.run(
@@ -199,7 +199,7 @@ Use \`!iam <affiliation> <name> <ucla_email>\` and verify your email address.`,
     return [{ message: e.toString() }, null];
   }
   await db.close();
-    
+
   return [
     null,
     `Successfully added your graduation year (${year}). Thank you!`
@@ -208,13 +208,13 @@ Use \`!iam <affiliation> <name> <ucla_email>\` and verify your email address.`,
 
 // toggle transfer student flag
 // linked to TRANSFER command
-const toggleTransfer = async function (userid) {
+const toggleTransfer = async function(userid) {
   // open db
   let db = await sqlite.open({
     filename: config.db_path,
     driver: sqlite3.Database,
   });
-    
+
   // check if user is verified
   let row = null;
   try {
@@ -238,10 +238,10 @@ const toggleTransfer = async function (userid) {
       null,
       `
 Sorry, I don't think you're verified!.
-Use \`!iam <affiliation> <name> <ucla_email>\` and verify your email address.`,
+Use \`!iam <affiliation> <name> <edu_email>\` and verify your email address.`,
     ];
   }
-    
+
   // toggle transfer flag in db
   try {
     await db.run(
@@ -260,25 +260,25 @@ Use \`!iam <affiliation> <name> <ucla_email>\` and verify your email address.`,
     return [{ message: e.toString() }, null];
   }
   await db.close();
-    
+
   return [
     null,
     `Successfully ${row.transfer_flag == 1 ? 'un' : ''}marked you as a transfer student. Thank you!`
   ];
 };
 
-const updateUserNickname = async function (userid, nickname, server) {
+const updateUserNickname = async function(userid, nickname, server) {
   // nickname length should be less than 20 chars
   if (nickname.length > 19) {
     return [null, 'Please enter a shorter name (max 19 characters).'];
   }
-    
+
   // open db
   let db = await sqlite.open({
     filename: config.db_path,
     driver: sqlite3.Database,
   });
-    
+
   // get current nickname and pronouns
   let row = null;
   try {
@@ -303,7 +303,7 @@ const updateUserNickname = async function (userid, nickname, server) {
 Invalid/unverified user.`,
     ];
   }
-    
+
   // update nickname on db
   try {
     await db.run(
@@ -322,7 +322,7 @@ Invalid/unverified user.`,
     return [{ message: e.toString() }, null];
   }
   await db.close();
-    
+
   // update nickname on server
   let member = await server.members.fetch(userid);
   if (!member) {
@@ -331,12 +331,12 @@ Invalid/unverified user.`,
       'User not found.'
     ];
   }
-  member.setNickname(nickname + (row.pronouns ? ` (${row.pronouns})`: ''));
-    
+  member.setNickname(nickname + (row.pronouns ? ` (${row.pronouns})` : ''));
+
   return [
     null,
     `Successfully changed: ${row.nickname} -> ${nickname}.`
   ];
 };
 
-module.exports = {setPronouns, setMajor, setYear, toggleTransfer, updateUserNickname};
+module.exports = { setPronouns, setMajor, setYear, toggleTransfer, updateUserNickname };

--- a/commands/verify.js
+++ b/commands/verify.js
@@ -53,10 +53,12 @@ const verify = async function(code, author, server, guest_role, verified_role, m
   }
 
   let domain = row.email.match(
-    '^[a-zA-Z0-9_.+-]+@(?:(?:[a-zA-Z0-9-]+.)?[a-zA-Z]+.)?.+\.edu$'
+    '^[a-zA-Z0-9_.+-]+@(?:(?:[a-zA-Z0-9-]+.)?[a-zA-Z]+.)?(' +
+    config.allowed_domains.join('|') +
+    ')$'
   );
 
-  if (row.affiliation === 'other' && !config.allowed_domains.includes(domain[1])) {
+  if (row.affiliation === 'other' && !(domain && config.allowed_domains.includes(domain[1]))) {
     await member.roles.add(guest_role);
   }
   else {

--- a/config.dev.js
+++ b/config.dev.js
@@ -10,6 +10,7 @@ module.exports = {
   discord: {
     server_id: '842102423345823765',
     gen_code_length: 6,
+    guest_role_name: 'Guest',
     verified_role_name: 'Verified',
     mod_role_name: 'Moderator',
     alumni_role_name: 'Alumni',
@@ -23,12 +24,12 @@ module.exports = {
     welcome: `
 Welcome to the official **ACM at UCLA** Discord community!
 
-To keep the server a safe place for everyone,  please verify yourself using your UCLA.edu email address. We recommend using **\`@g.ucla.edu\`** over **\`@ucla.edu\`** for faster verification. Also, please let us know your affiliation with UCLA (student/alumni/other).
+To keep the server a safe place for everyone,  please verify yourself using your university (.edu) email address. Also, please let us know your affiliation with UCLA (student/alumni/other). Use "other" if you're not a UCLA student. If you are a UCLA student, please make sure to use your UCLA email address. We recommend using **\`@g.ucla.edu\`** over **\`@ucla.edu\`** for faster verification.
 
 **By verifying, you agree to the rules and guidelines posted in #:information_source:server-info**
 To obtain your verification code, reply to this message with the following command:
 \`\`\`MD
-!iam <affiliation> <name> <ucla_email>
+!iam <affiliation> <name> <edu_email>
 \`\`\`
 `,
   },

--- a/config.prod.js
+++ b/config.prod.js
@@ -10,6 +10,7 @@ module.exports = {
   discord: {
     server_id: '702801010426511373',
     gen_code_length: 6,
+    guest_role_name: 'Guest',
     verified_role_name: 'Verified',
     mod_role_name: 'Moderator',
     alumni_role_name: 'Alumni',
@@ -23,12 +24,12 @@ module.exports = {
     welcome: `
 Welcome to the official **ACM at UCLA** Discord community!
 
-To keep the server a safe place for everyone,  please verify yourself using your UCLA.edu email address. We recommend using **\`@g.ucla.edu\`** over **\`@ucla.edu\`** for faster verification. Also, please let us know your affiliation with UCLA (student/alumni/other).
+To keep the server a safe place for everyone,  please verify yourself using your university (.edu) email address. Also, please let us know your affiliation with UCLA (student/alumni/other). Use "other" if you're not a UCLA student. If you are a UCLA student, please make sure to use your UCLA email address. We recommend using **\`@g.ucla.edu\`** over **\`@ucla.edu\`** for faster verification.
 
 **By verifying, you agree to the rules and guidelines posted in #:information_source:server-info**
 To obtain your verification code, reply to this message with the following command:
 \`\`\`MD
-!iam <affiliation> <name> <ucla_email>
+!iam <affiliation> <name> <edu_email>
 \`\`\`
 `,
   },


### PR DESCRIPTION
Non-UCLA university students (with a .edu email address) can now verify and access the discord server.

On successful verification, they will obtain the "Guest" role **in place of** the "Verified" role.

Only "other" affiliated users will be allowed to use a non-UCLA email address. A "student" or "alumni" must still use to a UCLA email address.

(Closes #23.)