### PR TITLE
Audit feature to mark graduated users as alumni

### DIFF
--- a/commands/setUser.js
+++ b/commands/setUser.js
@@ -72,7 +72,7 @@ const audit = async function(server, alumni_role) {
 
   return [
     null,
-    `Successfully audited. Thank you!`
+    'Successfully audited. Thank you!'
   ];
 };
 

--- a/commands/setUser.js
+++ b/commands/setUser.js
@@ -84,21 +84,29 @@ Use \`/iam\` to verify your email address.`,
 
   await db.close();
 
+  let count = 0;
   rows.forEach(async(user) => {
     let id = user['userid'];
     let server_member = await server.members.fetch(id);
 
-    if (server_member.roles.cache.some((role) => role.name === officer_role.name)) {
-      await server_member.roles.remove(officer_role.id);
-      await server_member.roles.add(alumni_officer_role);
-    }
+    if(server_member) {
+      try {
+        if (server_member.roles.cache.some((role) => role.name === officer_role.name)) {
+          await server_member.roles.remove(officer_role.id);
+          await server_member.roles.add(alumni_officer_role);
+        }
 
-    await server_member.roles.add(alumni_role);
+        await server_member.roles.add(alumni_role);
+        count++;
+      } catch(e) {
+        console.error(e.toString());
+      }
+    }
   });
 
   return [
     null,
-    'Successfully audited. Thank you!'
+    `Audit successful. ${count === 0 ? 'No users to update.' : `Updated ${count} user${count > 1 ? 's' : ''}.`} Thank you!`
   ];
 };
 

--- a/commands/setUser.js
+++ b/commands/setUser.js
@@ -2,7 +2,7 @@ const sqlite = require('sqlite');
 const sqlite3 = require('sqlite3');
 const config = require('../config.' + process.env.NODE_ENV_MODE);
 
-const audit = async function(server, alumni_role) {
+const audit = async function(server, alumni_role, officer_role, alumni_officer_role) {
   // open db
   let db = await sqlite.open({
     filename: config.db_path,
@@ -60,14 +60,13 @@ const audit = async function(server, alumni_role) {
   rows.forEach(async(user) => {
     let id = user['userid'];
     let server_member = await server.members.fetch(id);
-    try {
-      await server_member.roles.remove('ACM Officer');
-    } catch (e) {
-      console.error(e.toString());
-    }
-    await server_member.roles.add(alumni_role);
 
-    //console.log(id);
+    if (server_member.roles.cache.some((role) => role.name === officer_role.name)) {
+      await server_member.roles.remove(officer_role.id);
+      await server_member.roles.add(alumni_officer_role);
+    }
+
+    await server_member.roles.add(alumni_role);
   });
 
   return [

--- a/commands/verify.js
+++ b/commands/verify.js
@@ -71,6 +71,7 @@ const verify = async function(code, member, guest_role, verified_role, mod_role,
   }
 
   // set nickname: <name> (<pronouns>)
+  // TODO: DISCORD API PERMISSIONS ERROR CHECKING for when user has higher role than bot
   member.setNickname(row.nickname + (row_user ? ` (${row_user.pronouns})` : ''));
 
   try {

--- a/config.dev.js
+++ b/config.dev.js
@@ -13,6 +13,7 @@ module.exports = {
     guest_role_name: 'Guest',
     verified_role_name: 'Verified',
     mod_role_name: 'Moderator',
+    student_role_name: 'Student',
     alumni_role_name: 'Alumni',
     officer_role_name: 'ACM Officer',
     officer_alumni_role_name: 'ACM Officer Emeritus',

--- a/config.dev.js
+++ b/config.dev.js
@@ -16,6 +16,7 @@ module.exports = {
     alumni_role_name: 'Alumni',
     officer_role_name: 'ACM Officer',
     officer_alumni_role_name: 'ACM Officer Emeritus',
+    pvp_role_name: 'PVP',
   },
   ses: {
     region: 'us-west-1',

--- a/config.dev.js
+++ b/config.dev.js
@@ -14,10 +14,12 @@ module.exports = {
     verified_role_name: 'Verified',
     mod_role_name: 'Moderator',
     alumni_role_name: 'Alumni',
+    officer_role_name: 'ACM Officer',
+    officer_alumni_role_name: 'ACM Officer Emeritus',
   },
   ses: {
     region: 'us-west-1',
-    sender: 'smahadev369@g.ucla.edu',
+    sender: 'acm@ucla.edu',
   },
   default_msgs: {
     welcome: `

--- a/config.prod.js
+++ b/config.prod.js
@@ -14,6 +14,8 @@ module.exports = {
     verified_role_name: 'Verified',
     mod_role_name: 'Moderator',
     alumni_role_name: 'Alumni',
+    officer_role_name: 'ACM Officer',
+    officer_alumni_role_name: 'ACM Officer Emeritus',
   },
   ses: {
     region: 'us-west-1',

--- a/config.prod.js
+++ b/config.prod.js
@@ -13,6 +13,7 @@ module.exports = {
     guest_role_name: 'Guest',
     verified_role_name: 'Verified',
     mod_role_name: 'Moderator',
+    student_role_name: 'Student',
     alumni_role_name: 'Alumni',
     officer_role_name: 'ACM Officer',
     officer_alumni_role_name: 'ACM Officer Emeritus',

--- a/config.prod.js
+++ b/config.prod.js
@@ -16,6 +16,7 @@ module.exports = {
     alumni_role_name: 'Alumni',
     officer_role_name: 'ACM Officer',
     officer_alumni_role_name: 'ACM Officer Emeritus',
+    pvp_role_name: 'PVP',
   },
   ses: {
     region: 'us-west-1',

--- a/main.js
+++ b/main.js
@@ -239,6 +239,13 @@ client.on('ready', async () => {
   modCommandIds.push(commandCreateRes.id);
 
   commandCreateRes = await server.commands.create({
+    name: 'audit',
+    description: 'Mark any students that have graduated as alumni',
+    defaultPermission: false,
+  });
+  modCommandIds.push(commandCreateRes.id);
+
+  commandCreateRes = await server.commands.create({
     name: 'name',
     description: 'Update user\'s nickname',
     options: [
@@ -402,6 +409,10 @@ client.on('interactionCreate', async interaction => {
 
   else if (command === 'whoami') {
     [err, message, embed] = await command_getUser.whoami(userId, server, Discord);
+  }
+
+  else if (command === 'audit') {
+    [err, message] = await command_setUser.audit(server, alumni_role);
   }
 
   else if (command === 'lookup') {

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ const client = new Discord.Client({
     Discord.Intents.FLAGS.GUILD_MEMBERS
   ]
 });
+
 let server = null;
 let guest_role = null;
 let verified_role = null;
@@ -18,6 +19,7 @@ let mod_role = null;
 let alumni_role = null;
 let officer_role = null;
 let alumni_officer_role = null;
+let pvp_role = null;
 
 
 const isModOrAdmin = member =>
@@ -57,6 +59,8 @@ client.on('ready', async () => {
   alumni_role = server.roles.cache.find((role) => role.name === config.discord.alumni_role_name);
   officer_role = server.roles.cache.find((role) => role.name === config.discord.officer_role_name);
   alumni_officer_role = server.roles.cache.find((role) => role.name === config.discord.officer_alumni_role_name);
+  pvp_role = server.roles.cache.find((role) => role.name === config.discord.pvp_role_name);
+
 
   // open db
   let db = await sqlite.open({
@@ -214,6 +218,12 @@ client.on('ready', async () => {
     description: 'View your registered information',
   });
 
+  const auditCommand = await server.commands.create({
+    name: 'audit',
+    description: 'Mark any students that have graduated as alumni',
+    defaultPermission: false,
+  });
+
   let commandCreateRes = await server.commands.create({
     name: 'lookup',
     description: 'Lookup a user',
@@ -240,13 +250,6 @@ client.on('ready', async () => {
         'required': true,
       }
     ],
-    defaultPermission: false,
-  });
-  modCommandIds.push(commandCreateRes.id);
-
-  commandCreateRes = await server.commands.create({
-    name: 'audit',
-    description: 'Mark any students that have graduated as alumni',
     defaultPermission: false,
   });
   modCommandIds.push(commandCreateRes.id);
@@ -347,6 +350,16 @@ client.on('ready', async () => {
       }],
     });
   });
+
+  fullPermissions.push({
+    id: auditCommand.id,
+    permissions: [{
+      id: pvp_role.id,
+      type: 'ROLE',
+      permission: true,
+    }]
+  });
+
   server.commands.permissions.set({ fullPermissions });
 });
 

--- a/main.js
+++ b/main.js
@@ -431,7 +431,7 @@ client.on('interactionCreate', async interaction => {
   }
 
   else if (command === 'audit') {
-    [err, message] = await command_setUser.audit(server, alumni_role, officer_role, alumni_officer_role);
+    [err, message] = await command_setUser.audit(userId, server, alumni_role, officer_role, alumni_officer_role);
   }
 
   else if (command === 'lookup') {

--- a/main.js
+++ b/main.js
@@ -16,6 +16,7 @@ let server = null;
 let guest_role = null;
 let verified_role = null;
 let mod_role = null;
+let student_role = null;
 let alumni_role = null;
 let officer_role = null;
 let alumni_officer_role = null;
@@ -56,6 +57,7 @@ client.on('ready', async () => {
   guest_role = server.roles.cache.find((role) => role.name === config.discord.guest_role_name);
   verified_role = server.roles.cache.find((role) => role.name === config.discord.verified_role_name);
   mod_role = server.roles.cache.find((role) => role.name === config.discord.mod_role_name);
+  student_role = server.roles.cache.find((role) => role.name === config.discord.student_role_name);
   alumni_role = server.roles.cache.find((role) => role.name === config.discord.alumni_role_name);
   officer_role = server.roles.cache.find((role) => role.name === config.discord.officer_role_name);
   alumni_officer_role = server.roles.cache.find((role) => role.name === config.discord.officer_alumni_role_name);
@@ -351,6 +353,7 @@ client.on('ready', async () => {
     });
   });
 
+  // PVP only permissions for audit command
   fullPermissions.push({
     id: auditCommand.id,
     permissions: [{
@@ -431,7 +434,7 @@ client.on('interactionCreate', async interaction => {
   }
 
   else if (command === 'audit') {
-    [err, message] = await command_setUser.audit(userId, server, alumni_role, officer_role, alumni_officer_role);
+    [err, message] = await command_setUser.audit(server, student_role, alumni_role, officer_role, alumni_officer_role);
   }
 
   else if (command === 'lookup') {

--- a/main.js
+++ b/main.js
@@ -16,6 +16,10 @@ let guest_role = null;
 let verified_role = null;
 let mod_role = null;
 let alumni_role = null;
+let officer_role = null;
+let alumni_officer_role = null;
+
+
 const isModOrAdmin = member =>
   member.permissions.has(Discord.Permissions.FLAGS.ADMINISTRATOR) ||
   member.roles.cache.has(mod_role.id);
@@ -51,6 +55,8 @@ client.on('ready', async () => {
   verified_role = server.roles.cache.find((role) => role.name === config.discord.verified_role_name);
   mod_role = server.roles.cache.find((role) => role.name === config.discord.mod_role_name);
   alumni_role = server.roles.cache.find((role) => role.name === config.discord.alumni_role_name);
+  officer_role = server.roles.cache.find((role) => role.name === config.discord.officer_role_name);
+  alumni_officer_role = server.roles.cache.find((role) => role.name === config.discord.officer_alumni_role_name);
 
   // open db
   let db = await sqlite.open({
@@ -412,7 +418,7 @@ client.on('interactionCreate', async interaction => {
   }
 
   else if (command === 'audit') {
-    [err, message] = await command_setUser.audit(server, alumni_role);
+    [err, message] = await command_setUser.audit(server, alumni_role, officer_role, alumni_officer_role);
   }
 
   else if (command === 'lookup') {


### PR DESCRIPTION
PR for [Alumni Management](https://github.com/uclaacm/ACM-at-UCLA-Discord-Bot/issues/22#issue-798341288) as outlined by Daniel.
Marks all current members that have graduated as alumni in the database and adds the alumni role. Additionally, if the member was an ACM Officer, changes the role to ACM Officer Alumni